### PR TITLE
Added a fix that if the tokenCreationException dosent create the toke…

### DIFF
--- a/lexer/src/main/kotlin/lexer/RegexTokenGenerator.kt
+++ b/lexer/src/main/kotlin/lexer/RegexTokenGenerator.kt
@@ -42,14 +42,10 @@ class RegexTokenGenerator(
             tokenCreationException?.generateToken(tokenRegexRule.getType(), match, Pair(start, numberLine), Pair(end, numberLine))?.let {
                 tokens.add(it)
             }
-                ?: tokens.add(
-                    Token(
-                        tokenRegexRule.getType(),
-                        match,
-                        Pair(start, numberLine),
-                        Pair(end, numberLine),
-                    ),
-                )
+
+            if (tokenCreationException == null) {
+                tokens.add(Token(tokenRegexRule.getType(), match, Pair(start, numberLine), Pair(end, numberLine)))
+            }
         }
         return tokens
     }


### PR DESCRIPTION
Added a fix that if the tokenCreationException dosent create the token is not added. This can affect if you do println (Hello). That should work. The method and parameters should be next to each other