### PR TITLE
fix: El archivo debe terminar con un separador

### DIFF
--- a/lexer/src/main/kotlin/lexer/Lexer.kt
+++ b/lexer/src/main/kotlin/lexer/Lexer.kt
@@ -9,4 +9,6 @@ interface Lexer {
     ): List<Token>
 
     fun isLineFinished(): Boolean
+
+    fun stillHaveTokens(): Boolean
 }

--- a/lexer/src/main/kotlin/lexer/LexerImpl.kt
+++ b/lexer/src/main/kotlin/lexer/LexerImpl.kt
@@ -33,6 +33,10 @@ class LexerImpl(private val tokenRules: Map<String, TokenRegexRule> = mapOf()) :
         return codeFraction.isEmpty()
     }
 
+    override fun stillHaveTokens(): Boolean {
+        return tokens.isNotEmpty()
+    }
+
     override fun lex(
         line: String,
         numberLine: Int,

--- a/printscript/src/main/kotlin/PrintScript.kt
+++ b/printscript/src/main/kotlin/PrintScript.kt
@@ -78,6 +78,9 @@ class PrintScript {
                 }
                 numberLine++
             }
+            if (lexer.stillHaveTokens()) {
+                throw Exception("File does not end with a separator")
+            }
 
             return output.joinToString("")
         } catch (e: Exception) {

--- a/printscript/src/test/kotlin/PrintScriptTest.kt
+++ b/printscript/src/test/kotlin/PrintScriptTest.kt
@@ -113,7 +113,7 @@ class PrintScriptTest {
     }
 
     @Test
-    fun testBasicOperation() {
+    fun test009BasicOperation() {
         val printScript = PrintScript()
         val path = "src/test/resources/operationFile.txt"
         val expectedOutput = "30\n"
@@ -122,7 +122,7 @@ class PrintScriptTest {
     }
 
     @Test
-    fun testOperationsAndVariableReassignation() {
+    fun test010OperationsAndVariableReassignation() {
         val printScript = PrintScript()
         val path = "src/test/resources/operationAndVariableReassignation.txt"
         val expectedOutput = "15\n" + "10\n" + "20\n"
@@ -131,7 +131,7 @@ class PrintScriptTest {
     }
 
     @Test
-    fun testStringNumberConcatenation() {
+    fun test011StringNumberConcatenation() {
         val printScript = PrintScript()
         val path = "src/test/resources/stringNumberConcatenation.txt"
         val expectedOutput = "Hello world 10\n"
@@ -140,10 +140,18 @@ class PrintScriptTest {
     }
 
     @Test
-    fun testAnalyzeWithSCAIssues() {
+    fun test012AnalyzeWithSCAIssues() {
         val printScript = PrintScript()
         val path = "src/test/resources/testFileWithSCAIssues.txt"
         val expectedOutput = "Invalid typing format in line 4 row 1"
         assertEquals(expectedOutput, printScript.analyze(path))
+    }
+
+    @Test
+    fun test013IfFileDoesNotEndWithSeparatorShouldThrowException() {
+        val printScript = PrintScript()
+        val path = "src/test/resources/testFileNotEndWithSeparator.txt"
+        val expectedOutput = "An error occurred while executing the script. File does not end with a separator"
+        assertEquals(expectedOutput, printScript.start(path))
     }
 }

--- a/printscript/src/test/resources/testFileNotEndWithSeparator.txt
+++ b/printscript/src/test/resources/testFileNotEndWithSeparator.txt
@@ -1,0 +1,5 @@
+let x : number = 10;
+let y : number = 20;
+println(x)
+
+


### PR DESCRIPTION
- Se corrigió un problema donde los archivos que no terminaban con un separador no tiraban ninguna excepcion.
- Se añadió una función al lexer para verificar que no haya tokens sin liberar.