### PR TITLE
refactor: Hacer pruebas unitarias independientes para el módulo Parser y Formatter

### DIFF
--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation project(':ast')
     implementation project(':token')
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation project(':parser')
 }
 
 

--- a/formatter/src/test/kotlin/OperationRuleTest.kt
+++ b/formatter/src/test/kotlin/OperationRuleTest.kt
@@ -1,6 +1,8 @@
 import astn.Method
+import astn.OperationHead
 import astn.OperationNumber
-import impl.ParserImpl
+import astn.OperationString
+import astn.OperationVariable
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -19,7 +21,7 @@ class OperationRuleTest {
     @Test
     fun test002_genericLineOperationWithNumbers() {
         val ast =
-            astn.OperationHead(
+            OperationHead(
                 Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
                 OperationNumber(Token(DataType.NUMBER_TYPE, "5", Pair(4, 0), Pair(5, 0))),
                 OperationNumber(Token(DataType.NUMBER_TYPE, "5", Pair(4, 0), Pair(5, 0))),
@@ -31,132 +33,138 @@ class OperationRuleTest {
 
     @Test
     fun test003_genericLineOfSimpleOperationWithParenthesis() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
+                    left = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
+                    right =
+                        OperationHead(
+                            operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                            left = OperationNumber(Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0))),
+                            right = OperationNumber(Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0))),
+                        ),
+                ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("3*(5+5)", result)
     }
 
     @Test
     fun test004_genericLineOfComplexOperationWithParenthesis() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "2", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_MINUS, "-", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "6", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_DIVIDE, "/", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "4", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "2", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_MINUS, "-", Pair(4, 0), Pair(5, 0)),
+                    left =
+                        OperationHead(
+                            operator = Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
+                            left =
+                                OperationHead(
+                                    operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                                    left = OperationNumber(Token(DataType.NUMBER_VALUE, "5", Pair(4, 0), Pair(5, 0))),
+                                    right = OperationNumber(Token(DataType.NUMBER_VALUE, "2", Pair(4, 0), Pair(5, 0))),
+                                ),
+                            right = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
+                        ),
+                    right =
+                        OperationHead(
+                            operator = Token(DataType.OPERATOR_MULTIPLY, "*", Pair(4, 0), Pair(5, 0)),
+                            left = OperationNumber(Token(DataType.NUMBER_VALUE, "6", Pair(4, 0), Pair(5, 0))),
+                            right =
+                                OperationHead(
+                                    operator = Token(DataType.OPERATOR_DIVIDE, "/", Pair(4, 0), Pair(5, 0)),
+                                    left = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
+                                    right =
+                                        OperationHead(
+                                            operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                                            left = OperationNumber(Token(DataType.NUMBER_VALUE, "4", Pair(4, 0), Pair(5, 0))),
+                                            right = OperationNumber(Token(DataType.NUMBER_VALUE, "2", Pair(4, 0), Pair(5, 0))),
+                                        ),
+                                ),
+                        ),
+                ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("(5+2)*3-6*(3/(4+2))", result)
     }
 
     @Test
     fun test005_genericLineOfOperationWithString() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                    left = OperationString(Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0))),
+                    right = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
+                ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("\"Hello\"+3", result)
     }
 
     @Test
     fun test006_genericLineOfOperationWithVariable() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                    left = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
+                    right = OperationVariable(Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0))),
+                ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("3+x", result)
     }
 
     @Test
     fun test007_genericLineOfOperationWithVariableAndString() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                    left =
+                        OperationString(
+                            Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
+                        ),
+                    right =
+                        OperationVariable(
+                            Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
+                        ),
+                ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("\"Hello\"+x", result)
     }
 
     @Test
     fun test008_genericLineOfOperationWithVariableAndStringAndNumber() {
-        val tokenList =
-            listOf(
+        val ast =
+            Method(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
-                Token(
-                    DataType.RIGHT_PARENTHESIS,
-                    ")",
-                    Pair(4, 0),
-                    Pair(5, 0),
+                OperationHead(
+                    operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                    left =
+                        OperationHead(
+                            operator = Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
+                            left = OperationString(Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0))),
+                            right = OperationVariable(Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0))),
+                        ),
+                    right = OperationNumber(Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0))),
                 ),
             )
-        val ast = ParserImpl().parse(tokenList)
         val operationRule = rules.OperationRule()
-        val result = operationRule.genericLine((ast as Method).value)
+        val result = operationRule.genericLine(ast.value)
         assertEquals("\"Hello\"+x+3", result)
     }
 

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation project(':token')
     implementation project(':ast')
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation project(':lexer')
 }
 
 test {

--- a/parser/src/test/kotlin/OperationBuilderTest.kt
+++ b/parser/src/test/kotlin/OperationBuilderTest.kt
@@ -28,7 +28,7 @@ class OperationBuilderTest {
     }
 
     @Test
-    fun testbuildOperationwithunexpectedtoken() {
+    fun testBuildOperationwithUnexpectedToken() {
         val tokens =
             listOf(
                 Token(DataType.UNKNOWN, "unknown", Pair(0, 0), Pair(0, 7)),

--- a/parser/src/test/kotlin/TestParser.kt
+++ b/parser/src/test/kotlin/TestParser.kt
@@ -2,8 +2,6 @@ import astn.EmptyAST
 import astn.VarDeclarationAssignation
 import exceptions.SyntacticError
 import impl.ParserImpl
-import lexer.LexerImpl
-import lexer.TokenRegexRule
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -13,32 +11,20 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TestParser {
-    val tokenRulesMap: Map<String, TokenRegexRule> =
-        mapOf(
-            "STRING_VALUE" to TokenRegexRule("\"(?:\\\\.|[^\"])*\"", DataType.STRING_VALUE),
-            "DECLARATION_VARIABLE" to TokenRegexRule("\\blet\\b", DataType.DECLARATION_VARIABLE),
-            "OPERATOR_PLUS" to TokenRegexRule("\\+", DataType.OPERATOR_PLUS),
-            "OPERATOR_MINUS" to TokenRegexRule("-", DataType.OPERATOR_MINUS),
-            "OPERATOR_MULTIPLY" to TokenRegexRule("\\*", DataType.OPERATOR_MULTIPLY),
-            "OPERATOR_DIVIDE" to TokenRegexRule("/", DataType.OPERATOR_DIVIDE),
-            "DOUBLE_DOTS" to TokenRegexRule(":", DataType.DOUBLE_DOTS),
-            "SEMICOLON" to TokenRegexRule(";", DataType.SEPARATOR),
-            "ASSIGNATION" to TokenRegexRule("=", DataType.ASSIGNATION),
-            "LEFT_PARENTHESIS" to TokenRegexRule("\\(", DataType.LEFT_PARENTHESIS),
-            "RIGHT_PARENTHESIS" to TokenRegexRule("\\)", DataType.RIGHT_PARENTHESIS),
-            "METHOD_CALL" to TokenRegexRule("\\b\\w+\\s*\\((?:[^()]*|\\([^()]*\\))*\\)", DataType.METHOD_CALL),
-            "COMA" to TokenRegexRule(",", DataType.COMA),
-            "NUMBER_TYPE" to TokenRegexRule("\\bnumber\\b", DataType.NUMBER_TYPE),
-            "STRING_TYPE" to TokenRegexRule("\\bstring\\b", DataType.STRING_TYPE),
-            "NUMBER_VALUE" to TokenRegexRule("\\b\\d+\\.?\\d*\\b", DataType.NUMBER_VALUE),
-            "VARIABLE_NAME" to TokenRegexRule("(?<!\")\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?!\")", DataType.VARIABLE_NAME),
-        )
-
     @Test
     fun testVariableDeclaration() {
         val parser = ParserImpl()
-        val lexerImpl = LexerImpl(tokenRulesMap)
-        val tokens = lexerImpl.lex("let x: number = 5;", 1)
+        val tokens =
+            listOf(
+                Token(DataType.DECLARATION_VARIABLE, "let", Pair(1, 1), Pair(1, 3)),
+                Token(DataType.VARIABLE_NAME, "x", Pair(1, 5), Pair(1, 5)),
+                Token(DataType.DOUBLE_DOTS, ":", Pair(1, 6), Pair(1, 6)),
+                Token(DataType.NUMBER_TYPE, "number", Pair(1, 8), Pair(1, 13)),
+                Token(DataType.ASSIGNATION, "=", Pair(1, 15), Pair(1, 15)),
+                Token(DataType.NUMBER_VALUE, "5", Pair(1, 17), Pair(1, 17)),
+                Token(DataType.SEPARATOR, ";", Pair(1, 18), Pair(1, 18)),
+            )
+
         val ast = parser.parse(tokens) as VarDeclarationAssignation
 
         assertNotNull(ast)


### PR DESCRIPTION
- Se refactorizaron las pruebas del módulo Parser y Formatter para que sean unitarias y no dependan de otros módulos.
- Esto mejora la modularidad y la robustez de las pruebas, asegurando que cada módulo sea probado de manera independiente.