### PR TITLE
Fix - CLI and PrintScript for Regex

### DIFF
--- a/cli/src/main/kotlin/Cli.kt
+++ b/cli/src/main/kotlin/Cli.kt
@@ -6,25 +6,25 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.prompt
 import java.io.File
 
-fun main(args: Array<String>) =
-    Cli().subcommands(
-        Execute(),
-        FormatFile(),
-        Analyze(),
-        ChangeFormatterConfig(),
-        ChangeLexerConfig(),
+fun main(args: Array<String>) {
+    val printScript = PrintScript(::input)
+    Cli(printScript).subcommands(
+        Execute(printScript),
+        FormatFile(printScript),
+        Analyze(printScript),
+        ChangeFormatterConfig(printScript),
+        ChangeLexerConfig(printScript),
     ).main(args)
+}
 
-class Cli : CliktCommand() {
+class Cli(private val printScript: PrintScript) : CliktCommand() {
     override fun run() = echo("Welcome to PrintScript CLI. Use --help to see the options.")
 }
 
-class Execute : CliktCommand(help = "Execute a PrintScript file") {
+class Execute(private val printScript: PrintScript) : CliktCommand(help = "Execute a PrintScript file") {
     private val filePath: String by option(help = "Path to the PrintScript file").prompt("Enter the file path")
 
     override fun run() {
-        val printScript = PrintScript(::input)
-
         try {
             val output = printScript.start(filePath)
             echo(output)
@@ -32,19 +32,13 @@ class Execute : CliktCommand(help = "Execute a PrintScript file") {
             echo("Error: ${e.message}", err = true)
         }
     }
-
-    private fun input(message: String): String {
-        print(message)
-        return readlnOrNull() ?: ""
-    }
 }
 
-class FormatFile : CliktCommand(help = "Format a PrintScript file") {
+class FormatFile(private val printScript: PrintScript) : CliktCommand(help = "Format a PrintScript file") {
     private val filePath: String by option(help = "Path to the PrintScript file to format").prompt("Enter the file path")
 
     override fun run() {
         try {
-            val printScript = PrintScript(::input)
             val formattedContent = printScript.format(filePath)
             File(filePath).writeText(formattedContent)
             echo("File formatted and updated successfully.")
@@ -52,68 +46,50 @@ class FormatFile : CliktCommand(help = "Format a PrintScript file") {
             echo("Error: ${e.message}", err = true)
         }
     }
-
-    private fun input(message: String): String {
-        print(message)
-        return readlnOrNull() ?: ""
-    }
 }
 
-class Analyze : CliktCommand(help = "Analyze a PrintScript file") {
+class Analyze(private val printScript: PrintScript) : CliktCommand(help = "Analyze a PrintScript file") {
     private val filePath: String by option(help = "Path to the PrintScript file to analyze").prompt("Enter the file path")
 
     override fun run() {
         try {
-            val printScript = PrintScript(::input)
             val analysis = printScript.analyze(filePath)
             echo(analysis)
         } catch (e: Exception) {
             echo("Error: ${e.message}", err = true)
         }
     }
-
-    private fun input(message: String): String {
-        print(message)
-        return readlnOrNull() ?: ""
-    }
 }
 
-class ChangeFormatterConfig : CliktCommand(help = "Change formatter configurations") {
+class ChangeFormatterConfig(private val printScript: PrintScript) : CliktCommand(help = "Change formatter configurations") {
     private val configFilePath: String by option(help = "Path to the configuration file").prompt("Enter the configuration file path")
 
     override fun run() {
         try {
-            val printScript = PrintScript(::input)
             printScript.changeFormatterConfig(configFilePath)
             echo("Formatter configurations updated successfully.")
         } catch (e: Exception) {
             echo("Error: ${e.message}", err = true)
         }
     }
-
-    private fun input(message: String): String {
-        print(message)
-        return readlnOrNull() ?: ""
-    }
 }
 
-class ChangeLexerConfig : CliktCommand(help = "Change lexer configurations") {
+class ChangeLexerConfig(private val printScript: PrintScript) : CliktCommand(help = "Change lexer configurations") {
     private val configFilePath: String by option(
         help = "Path to the lexer configuration file",
     ).prompt("Enter the lexer configuration file path")
 
     override fun run() {
         try {
-            val printScript = PrintScript(::input)
             printScript.updateRegexRules(configFilePath)
             echo("Lexer configurations updated successfully.")
         } catch (e: Exception) {
             echo("Error: ${e.message}", err = true)
         }
     }
+}
 
-    private fun input(message: String): String {
-        print(message)
-        return readlnOrNull() ?: ""
-    }
+fun input(message: String): String {
+    print(message)
+    return readlnOrNull() ?: ""
 }

--- a/cli/src/main/kotlin/Cli.kt
+++ b/cli/src/main/kotlin/Cli.kt
@@ -75,13 +75,13 @@ class ChangeFormatterConfig(private val printScript: PrintScript) : CliktCommand
 }
 
 class ChangeLexerConfig(private val printScript: PrintScript) : CliktCommand(help = "Change lexer configurations") {
-    private val configFilePath: String by option(
+    private val filePath: String by option(
         help = "Path to the lexer configuration file",
     ).prompt("Enter the lexer configuration file path")
 
     override fun run() {
         try {
-            printScript.updateRegexRules(configFilePath)
+            printScript.updateRegexRules(filePath)
             echo("Lexer configurations updated successfully.")
         } catch (e: Exception) {
             echo("Error: ${e.message}", err = true)

--- a/cli/src/test/kotlin/CliTest.kt
+++ b/cli/src/test/kotlin/CliTest.kt
@@ -1,24 +1,32 @@
 import com.github.ajalt.clikt.testing.test
 import org.example.Execute
 import org.example.FormatFile
+import org.example.PrintScript
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.io.File
 
 class CliTest {
+    private val printScript = PrintScript(::input)
+
     @Test
     fun testExecuteCommand() {
-        val command = Execute()
+        val command = Execute(printScript)
         val result = command.test("--file-path=src/test/resources/testFile.txt")
         assertEquals("10\n\n", result.output)
     }
 
     @Test
     fun testFinalFormattedFile() {
-        val command = FormatFile()
+        val command = FormatFile(printScript)
         command.test("--file-path=src/test/resources/testFile.txt")
         val expectedContent = "let x:number=10;\n\nprintln(x);\n"
         val actualContent = File("src/test/resources/testFile.txt").readText()
         assertEquals(expectedContent, actualContent)
     }
+}
+
+fun input(message: String): String {
+    print(message)
+    return readlnOrNull() ?: ""
 }

--- a/printscript/src/main/kotlin/PrintScript.kt
+++ b/printscript/src/main/kotlin/PrintScript.kt
@@ -28,7 +28,7 @@ import java.io.FileNotFoundException
  */
 
 class PrintScript(private val loadInput: (String) -> String, private val version: String = "1.1") {
-    private var lexer: Lexer = LexerImpl(getLexerDefaultRules())
+    private var lexer: Lexer = LexerImpl(loadLexerRules())
     private val parser: Parser = ParserImpl()
     private val interpreter: Interpreter = InterpreterImpl(loadInput, { enterIfScope() }, { mergeScopes() })
     private val sca: SCA = SCAImpl(mapOf("CamelCaseFormat" to true, "SnakeCaseFormat" to true, "MethodNoExpresion" to true))
@@ -90,15 +90,8 @@ class PrintScript(private val loadInput: (String) -> String, private val version
         val json = file.readText()
         val newRegexRules = JSONManager.jsonToMap<TokenRegexRule>(json)
         lexer = LexerImpl(newRegexRules)
-    }
-    private fun getLexerDefaultRules(): Map<String, TokenRegexRule> {
-        val fileName = if (version == "1.1") "LexerFullRules.json" else "LexerDefaultRules.json"
-        var file = File("src/main/resources/$fileName")
-        if (!file.exists()) {
-            file = File("PrintScript/src/main/resources/$fileName")
-        }
-        val json = file.readText()
-        return JSONManager.jsonToMap<TokenRegexRule>(json)
+
+        saveLexerRules(newRulesPath)
     }
 
     fun changeFormatterConfig(configFilePath: String) {
@@ -140,5 +133,20 @@ class PrintScript(private val loadInput: (String) -> String, private val version
         }
 
         storedVariables = storedVariables.dropLast(1)
+    }
+
+    private fun loadLexerRules(): Map<String, TokenRegexRule> {
+        val fileName = "lexerRules.json"
+        var file = File(fileName)
+        if (!file.exists()) {
+            file = File("src/main/resources/LexerFullRules.json")
+        }
+        val json = file.readText()
+        return JSONManager.jsonToMap<TokenRegexRule>(json)
+    }
+
+    private fun saveLexerRules(newRulesPath: String) {
+        val file = File("lexerRules.json")
+        file.writeText(File(newRulesPath).readText())
     }
 }

--- a/printscript/src/main/kotlin/PrintScript.kt
+++ b/printscript/src/main/kotlin/PrintScript.kt
@@ -82,11 +82,15 @@ class PrintScript(private val loadInput: (String) -> String, private val version
         }
     }
 
-    fun updateRegexRules(newRules: String) {
-        val rulesMap = JSONManager.jsonToMap<TokenRegexRule>(newRules)
-        lexer = LexerImpl(rulesMap)
+    fun updateRegexRules(newRulesPath: String) {
+        val file = File(newRulesPath)
+        if (!file.exists()) {
+            throw FileNotFoundException("File not found: $newRulesPath")
+        }
+        val json = file.readText()
+        val newRegexRules = JSONManager.jsonToMap<TokenRegexRule>(json)
+        lexer = LexerImpl(newRegexRules)
     }
-
     private fun getLexerDefaultRules(): Map<String, TokenRegexRule> {
         val fileName = if (version == "1.1") "LexerFullRules.json" else "LexerDefaultRules.json"
         var file = File("src/main/resources/$fileName")

--- a/printscript/src/test/kotlin/PrintScriptTest.kt
+++ b/printscript/src/test/kotlin/PrintScriptTest.kt
@@ -218,7 +218,17 @@ class PrintScriptTest {
         assertEquals(expectedOutput, printScript.format(path))
     }
 
-    fun input(message: String): String {
+    @Test
+    fun test020UpdateLexerConfigurationAndParseFile() {
+        val printScript = PrintScript(::input)
+        val path = "src/test/resources/clitestDeclar.txt"
+        val expectedOutput = "25\n"
+        printScript.updateRegexRules("src/test/resources/newRegex.json")
+        assertEquals(expectedOutput, printScript.start(path))
+        printScript.updateRegexRules("src/test/resources/LexerFullRules.json")
+    }
+
+    private fun input(message: String): String {
         return message
     }
 }

--- a/printscript/src/test/resources/LexerFullRules.json
+++ b/printscript/src/test/resources/LexerFullRules.json
@@ -11,6 +11,18 @@
     "pattern": "\\blet\\b",
     "type": "DECLARATION_VARIABLE"
   },
+  "DECLARATION_IMMUTABLE": {
+    "pattern": "\\bconst\\b",
+    "type": "DECLARATION_IMMUTABLE"
+  },
+  "IFSTATEMENT": {
+    "pattern": "\\bif\\b",
+    "type": "IF_STATEMENT"
+  },
+  "ELSESTATEMENT": {
+    "pattern": "\\}\\s*else",
+    "type": "ELSE_STATEMENT"
+  },
   "OPERATOR_PLUS": {
     "pattern": "\\+",
     "type": "OPERATOR_PLUS"
@@ -47,7 +59,15 @@
     "pattern": "\\)",
     "type": "RIGHT_PARENTHESIS"
   },
-  "\\b\\w+\\s*\\((?:[^()]*|\\([^()]*\\))*\\)": {
+  "LEFT_BRACKET": {
+    "pattern": "\\{",
+    "type": "LEFT_BRACKET"
+  },
+  "RIGHT_BRACKET": {
+    "pattern": "\\}",
+    "type": "RIGHT_BRACKET"
+  },
+  "METHOD_CALL": {
     "pattern": "\\b\\w+\\s*\\((?:[^()]*|\\([^()]*\\))*\\)",
     "type": "METHOD_CALL"
   },
@@ -62,6 +82,18 @@
   "\\bstring\\b": {
     "pattern": "\\bstring\\b",
     "type": "STRING_TYPE"
+  },
+  "\\bboolean\\b": {
+    "pattern": "\\bboolean\\b",
+    "type": "BOOLEAN_TYPE"
+  },
+  "\\btrue\\b": {
+    "pattern": "\\btrue\\b",
+    "type": "BOOLEAN_VALUE"
+  },
+  "\\bfalse\\b": {
+    "pattern": "\\bfalse\\b",
+    "type": "BOOLEAN_VALUE"
   },
   "\\b\\d+\\.?\\d*\\b": {
     "pattern": "\\b\\d+\\.?\\d*\\b",

--- a/printscript/src/test/resources/booleanTest.txt
+++ b/printscript/src/test/resources/booleanTest.txt
@@ -1,4 +1,4 @@
-let x : boolean;
+let x :boolean;
 x = true;
 x = false;
 println(x);

--- a/printscript/src/test/resources/clitestDeclar.txt
+++ b/printscript/src/test/resources/clitestDeclar.txt
@@ -1,0 +1,3 @@
+declar x:number = 15;
+declar y:number = 10;
+println(x + y);

--- a/printscript/src/test/resources/newRegex.json
+++ b/printscript/src/test/resources/newRegex.json
@@ -8,7 +8,7 @@
     "type": "STRING_VALUE"
   },
   "DECLARATION": {
-    "pattern": "\\blet\\b",
+    "pattern": "\\bdeclar\\b",
     "type": "DECLARATION_VARIABLE"
   },
   "OPERATOR_PLUS": {


### PR DESCRIPTION
- Fixed PrintScript for updating regex rules. Now the updated file is persisted and fetched when restarted
- Fixed CLI to comply with new changes and use a global PrintScript when interacting with different methods
- Added tests to PrintScript module