### PR TITLE
- versions update

### DIFF
--- a/ast/build.gradle
+++ b/ast/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
     mavenCentral()
 }
 
-def projectVersion = "1.1.7"
+def projectVersion = "1.2.0"
 group = "com.IngsisMEGE"
 
 subprojects {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/formatter/build.gradle
+++ b/formatter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/interpreter/build.gradle
+++ b/interpreter/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/lexer/build.gradle
+++ b/lexer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/printscript/build.gradle
+++ b/printscript/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/printscript/src/main/kotlin/PrintScript.kt
+++ b/printscript/src/main/kotlin/PrintScript.kt
@@ -63,11 +63,16 @@ class PrintScript(private val loadInput: (String) -> String) {
         envs: Map<String, String>,
     ): String {
         return processFile(path) { line, numberLine ->
-            interpreter.readASTWithEnv(
-                lexAndParse(line, numberLine),
-                storedVariables.last(),
-                envs,
-            )
+            val output =
+                interpreter.readASTWithEnv(
+                    lexAndParse(line, numberLine),
+                    storedVariables.last(),
+                    envs,
+                )
+            if (output.isNotEmpty()) {
+                outputs.add(output)
+            }
+            output
         }
     }
 

--- a/sca/build.gradle
+++ b/sca/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()

--- a/token/build.gradle
+++ b/token/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.IngsisMEGE'
-version = '1.1.7'
+version = '1.2.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
- made outputs save when using start with env

![a](https://media.tenor.com/uy_OBkkROWIAAAAM/yummy-tongue.gif)